### PR TITLE
Add logging for worker thread start/end.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,7 @@ plugins {
 }
 
 group 'com.github.grishberg'
-version '1.6.1'
+version '1.6.2'
 
 apply plugin: 'kotlin'
 

--- a/src/main/java/com/github/grishberg/tests/DeviceCommandsRunner.java
+++ b/src/main/java/com/github/grishberg/tests/DeviceCommandsRunner.java
@@ -34,25 +34,29 @@ class DeviceCommandsRunner {
         final RunnerLogger logger = context.getLogger();
         for (ConnectedDeviceWrapper device : devices) {
             new Thread(() -> {
+                long tid = Thread.currentThread().getId();
+                final String threadTag = String.format("%s/%s", TAG, tid);
+                logger.i(threadTag, "New thread {} started to run commands on {}", tid, device);
                 try {
                     List<DeviceRunnerCommand> commands = commandProvider.provideCommandsForDevice(device,
                             testPlanProvider, environment);
                     for (DeviceRunnerCommand command : commands) {
-                        logger.i(TAG, "Before executing device = {} command = {}",
+                        logger.i(threadTag, "Before executing device = {} command = {}",
                                 device, command.toString());
                         DeviceCommandResult result = command.execute(device, context);
-                        logger.i(TAG, "After executing device = {} command = {}",
+                        logger.i(threadTag, "After executing device = {} command = {}",
                                 device, command.toString());
                         if (result.isFailed()) {
                             hasFailedTests = true;
                         }
                     }
                 } catch (Throwable e) {
-                    logger.e(TAG, "Execute command exception:", e);
+                    logger.e(threadTag, "Execute command exception:", e);
                     commandException = e;
                 } finally {
                     deviceCounter.countDown();
                 }
+                logger.i(threadTag, "Thread {} ({}) is finished", tid, device);
             }).start();
         }
         deviceCounter.await();


### PR DESCRIPTION
Add logging for worker thread start/end.
Add thread id to log tag.

Самое основное тут - отсечки начала и конца тредов. Thread id - это второстепенное (может пригодится).
Так мы сможем гарантированно понимать, отработали ли треды до конца, или умерли где-то на середине.

Example log:

```
[24.547 s] I: [DCR/26] New thread 26 started to run commands on ConnectedDeviceWrapper{sn=emulator-5554, isOnline=true, name='phone_dev-0 [emulator-5554]'}
[24.547 s] I: [DCR/25] New thread 25 started to run commands on ConnectedDeviceWrapper{sn=emulator-5556, isOnline=true, name='phone_dev-1 [emulator-5556]'}
...
[59.146 s] I: [DCR/25] After executing device = ConnectedDeviceWrapper{sn=emulator-5556, isOnline=true, name='phone_dev-1 [emulator-5556]'} command = com.yandex.gradle.plugins.tests.features.ClearConfigCommand@64f344da
[59.146 s] I: [DCR/25] Thread 25 (ConnectedDeviceWrapper{sn=emulator-5556, isOnline=true, name='phone_dev-1 [emulator-5556]'}) is finished
```