### PR TITLE
Add logging of ADB commands. Bump version to 1.6.3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,7 @@ plugins {
 }
 
 group 'com.github.grishberg'
-version '1.6.2'
+version '1.6.3'
 
 apply plugin: 'kotlin'
 

--- a/src/main/java/com/github/grishberg/tests/ConnectedDeviceWrapper.java
+++ b/src/main/java/com/github/grishberg/tests/ConnectedDeviceWrapper.java
@@ -14,6 +14,10 @@ import java.util.concurrent.TimeUnit;
 
 /**
  * Wraps {@link IDevice} interface.
+ *
+ * Adds useful extra utility methods like pullCoverageFile(), getWidth(), getHeight(), etc.
+ * Adds synchronization (no parallel commands when multiple devices are connected).
+ * Adds verbose logging.
  */
 public class ConnectedDeviceWrapper implements IShellEnabledDevice, DeviceShellExecuter {
     private static final String TAG = ConnectedDeviceWrapper.class.getSimpleName();
@@ -35,6 +39,8 @@ public class ConnectedDeviceWrapper implements IShellEnabledDevice, DeviceShellE
                                                  long maxTimeToOutputResponse,
                                                  TimeUnit maxTimeUnits) throws TimeoutException,
             AdbCommandRejectedException, ShellCommandUnresponsiveException, IOException {
+        logger.d(TAG, "Execute shell command on {}: \"{}\"",
+                device.getName(), command);
         device.executeShellCommand(command, receiver, maxTimeToOutputResponse, maxTimeUnits);
     }
 
@@ -121,6 +127,8 @@ public class ConnectedDeviceWrapper implements IShellEnabledDevice, DeviceShellE
 
     @Override
     public synchronized void pullFile(String temporaryCoverageCopy, String path) throws CommandExecutionException {
+        logger.d(TAG, "Pull file from {}: \"{}\"",
+                device.getName(), path);
         try {
             device.pullFile(temporaryCoverageCopy, path);
         } catch (Throwable e) {
@@ -138,6 +146,8 @@ public class ConnectedDeviceWrapper implements IShellEnabledDevice, DeviceShellE
 
     public synchronized void installPackage(String absolutePath, boolean reinstall, String extraArgument)
             throws InstallException {
+        logger.d(TAG, "Install package on {}: \"{}\"",
+                device.getName(), absolutePath);
         device.installPackage(absolutePath, reinstall, extraArgument);
     }
 
@@ -158,6 +168,7 @@ public class ConnectedDeviceWrapper implements IShellEnabledDevice, DeviceShellE
                                               final ILogger logger) throws PullCoverageException {
         MultiLineReceiver outputReceiver = new MultilineLoggerReceiver(logger);
 
+        // TODO: Why another logger is used here?
         logger.verbose("ConnectedDeviceWrapper '%s': fetching coverage data from %s",
                 getName(), coverageFile);
         try {
@@ -182,6 +193,8 @@ public class ConnectedDeviceWrapper implements IShellEnabledDevice, DeviceShellE
                                                  long maxTimeout, long maxTimeToOutputResponse,
                                                  TimeUnit maxTimeUnits) throws TimeoutException,
             AdbCommandRejectedException, ShellCommandUnresponsiveException, IOException {
+        logger.d(TAG, "Execute shell command on {}: \"{}\"",
+                device.getName(), command);
         device.executeShellCommand(command, receiver, maxTimeout, maxTimeToOutputResponse, maxTimeUnits);
     }
 


### PR DESCRIPTION
Логирование на уровне d()  - клиент может обрезать лишнее логирование, настроив свой логгер на нужный уровень, уменьшив уровень вербозности.
Сейчас 80% логов создаёт [InstrumentalTestPlanProvider], причем, его логи - на уровне i().
Поэтому, этот логгер - как капля в море.
Размер лога браузерного рана увеличился на 6 Kb, при полном размере лога в 2.4 Mb. В лог добавилось лишь 30 новых строк. (но это не полный ран тестов, если что).

Излишне вербозное логирование - мелкая досадная неприятность (если человек не умеет пользоваться командой grep). Отсутствие информативности в логах - большая боль. И она перевешивает первое в 10 раз.

Example log

```
// Test launcher started:
[1.758 s] D: [ConnectedDeviceWrapper] Install package on phone_dev-1 [emulator-5556]: "/home/kindrik/work/yb/browser2/src/out/Debug_x86/apks/browser-x86-canary-api21-local-debug.apk"
[1.758 s] D: [ConnectedDeviceWrapper] Install package on phone_dev-0 [emulator-5554]: "/home/kindrik/work/yb/browser2/src/out/Debug_x86/apks/browser-x86-canary-api21-local-debug.apk"

// Tests listing
[63.805 s] D: [ConnectedDeviceWrapper] Execute shell command on phone_dev-1 [emulator-5556]: "am instrument -r -w -e disableAnalytics true -e shardIndex 0 -e startedFromCustomAndroidTestTask true -e log true -e listener com.github.grishberg.annotationprinter.AnnotationsTestPrinter -e numShards 2 -e abro_device_type PHONE com.yandex.browser.tests/com.yandex.browser.EspressoRunner"
[63.805 s] D: [ConnectedDeviceWrapper] Execute shell command on phone_dev-0 [emulator-5554]: "am instrument -r -w -e disableAnalytics true -e shardIndex 1 -e startedFromCustomAndroidTestTask true -e log true -e listener com.github.grishberg.annotationprinter.AnnotationsTestPrinter -e numShards 2 -e abro_device_type PHONE com.yandex.browser.tests/com.yandex.browser.EspressoRunner"


// Tests require disabling animations
[77.244 s] D: [ConnectedDeviceWrapper] Execute shell command on phone_dev-1 [emulator-5556]: "settings put global window_animation_scale 0"
[77.244 s] D: [ConnectedDeviceWrapper] Execute shell command on phone_dev-0 [emulator-5554]: "settings put global window_animation_scale 0"
[77.747 s] D: [ConnectedDeviceWrapper] Execute shell command on phone_dev-1 [emulator-5556]: "settings put global transition_animation_scale 0"
[77.766 s] D: [ConnectedDeviceWrapper] Execute shell command on phone_dev-0 [emulator-5554]: "settings put global transition_animation_scale 0"
[78.132 s] D: [ConnectedDeviceWrapper] Execute shell command on phone_dev-0 [emulator-5554]: "settings put global animator_duration_scale 0"
[78.211 s] D: [ConnectedDeviceWrapper] Execute shell command on phone_dev-1 [emulator-5556]: "settings put global animator_duration_scale 0"

// Force features
[78.554 s] D: [ConnectedDeviceWrapper] Execute shell command on phone_dev-0 [emulator-5554]: "echo 'yandex --disable-async-activity-ioc-registration --force-features=-search_2_bro-custom_ntp' > /data/local/tmp/yandex-browser-command-line"
[78.71 s] D: [ConnectedDeviceWrapper] Execute shell command on phone_dev-1 [emulator-5556]: "echo 'yandex --disable-async-activity-ioc-registration ' > /data/local/tmp/yandex-browser-command-line"

// Test runner finished
[105.693 s] I: [Utilities] Finished merging xml report into yandex_browser_instrumentation_tests.xml
[108.661 s] D: [ConnectedDeviceWrapper] Execute shell command on phone_dev-1 [emulator-5556]: "rm -rf /sdcard/allure-results"
[111.082 s] D: [ConnectedDeviceWrapper] Execute shell command on phone_dev-0 [emulator-5554]: "rm -rf /sdcard/allure-results"
[111.688 s] I: [StandaloneModeLauncher] Everything is GREEN.

```