### PR TITLE
Add test count logging, add API method to get test count.

### DIFF
--- a/src/main/java/com/github/grishberg/tests/planner/InstrumentalTestHolder.java
+++ b/src/main/java/com/github/grishberg/tests/planner/InstrumentalTestHolder.java
@@ -10,4 +10,9 @@ public interface InstrumentalTestHolder {
     Iterator<TestPlanElement> provideTestNodeElementsIterator();
 
     List<TestPlanElement> provideCompoundTestPlan();
+
+    /**
+     * Returns total count of tests (TestPlanElement items) that this class holds.
+     */
+    int size();
 }

--- a/src/main/java/com/github/grishberg/tests/planner/InstrumentalTestHolderImpl.java
+++ b/src/main/java/com/github/grishberg/tests/planner/InstrumentalTestHolderImpl.java
@@ -47,6 +47,11 @@ public class InstrumentalTestHolderImpl implements InstrumentalTestHolder {
         return compoundPlans;
     }
 
+    @Override
+    public int size() {
+        return planList.size();
+    }
+
     /**
      * Returns tree-items in flat list.
      */

--- a/src/main/java/com/github/grishberg/tests/planner/InstrumentalTestPlanProvider.java
+++ b/src/main/java/com/github/grishberg/tests/planner/InstrumentalTestPlanProvider.java
@@ -34,7 +34,8 @@ public class InstrumentalTestPlanProvider {
 
     public List<TestPlanElement> provideTestPlan(ConnectedDeviceWrapper device,
                                                  Map<String, String> instrumentalArgs) throws CommandExecutionException {
-        logger.i(TAG, "provideTestPlan for device {}", device.getName());
+        logger.i(TAG, "Get list of tests in \"{}\" app on {}",
+                instrumentationInfo.getInstrumentalPackage(), device.getName());
         HashMap<String, String> args = new HashMap<>(instrumentalArgs);
         args.put("log", "true");
 
@@ -62,6 +63,9 @@ public class InstrumentalTestPlanProvider {
         } catch (Throwable e) {
             throw new CommandExecutionException(e);
         }
+        logger.i(TAG, "Found {} tests in {} using device {}",
+                receiver.getTestInstances().size(), instrumentationInfo.getInstrumentalPackage(),
+                device.getName());
 
         return receiver.getTestInstances();
     }

--- a/src/test/java/com/github/grishberg/tests/planner/InstrumentalTestHolderTest.java
+++ b/src/test/java/com/github/grishberg/tests/planner/InstrumentalTestHolderTest.java
@@ -42,4 +42,9 @@ public class InstrumentalTestHolderTest {
         List<TestPlanElement> elements = holder.provideCompoundTestPlan();
         Assert.assertEquals(3, elements.size());
     }
+
+    @Test
+    public void size() {
+        Assert.assertEquals(7, holder.size());
+    }
 }


### PR DESCRIPTION
Тут сделаны 2 штуки:
1) Логируем число тестов сразу после извлечения из девайсов + парсинга
2) Добавляем API метод `size()` в контейнер (холдер) для TestPlanElement. Этот контейнер совершает сложные манипуляции с этими тест-планами - прогоняет через `PackageTreeGenerator`, который сначала строит дерево, затем обратно разворачивает это дерево в плоский список, и очевидно, что в ходе таких действий число тестов могло поменяться. `size()` позволяет узнать начальное число. 
3) Конечное число можно посчитать, итерируя `Iterator<TestPlanElement>` получаемый из холдера, поэтому, ничего больше не понадобилось. 

Если всё хорошо, то числа из всех 3 пунктов должны совпадать. Неважно, что будет 3 раза логироваться одна и та же циферка, зато это даст гарантию, что мы на этом этапе ничего не потеряли.

Example log:

```
[79.885 s] I: [InstrumentalTestPlanProvider] Found 263 tests in com.yandex.browser.tests using device phone_dev-0 [emulator-5554]
[79.889 s] I: [ADCP] TestPlan holder contains 263 items.

```