### PR TITLE
Add TestPlanElement.getFullTestName() method.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,7 @@ plugins {
 }
 
 group 'com.github.grishberg'
-version '1.6.5'
+version '1.6.6'
 
 apply plugin: 'kotlin'
 

--- a/src/main/java/com/github/grishberg/tests/planner/TestPlanElement.java
+++ b/src/main/java/com/github/grishberg/tests/planner/TestPlanElement.java
@@ -71,6 +71,21 @@ public class TestPlanElement {
         return className;
     }
 
+    /**
+     * Returns full test name in dot-separated format: <package name>.<class name>.<test name>.
+     * Useful for logging (some projects prefer dot-separated representation).
+     */
+    public String getFullTestNameDotSeparated() {
+        return className + "." + methodName;
+    }
+
+    /**
+     * Returns full test name: <package name>.<class name>#<test name>.
+     */
+    public String getFullTestName() {
+        return className + "#" + methodName;
+    }
+
     public List<AnnotationInfo> getAnnotations() {
         return Collections.unmodifiableList(annotations);
     }
@@ -113,7 +128,7 @@ public class TestPlanElement {
      */
     public String getAmInstrumentCommand() {
         if (type == NodeType.METHOD) {
-            return className + "#" + methodName;
+            return getFullTestName();
         }
         String prefix = "";
         if (parent != null) {


### PR DESCRIPTION
This method is to be used by external code for logging.

Пришлось добавить 2 метода.
Метод с "#" пригодился для внутреннего использования, а также нужен в целом, т.к. выдаёт в стандартном формате.
Метод с "." нужен для браузера, т.к. мы традиционно оперируем с названиями тестов через точку - для универсальности с С++ тестами, и с другими платформами.