### PR TITLE
v1.6.10 TestIdentifier can be null

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,7 @@ plugins {
 }
 
 group 'com.github.grishberg'
-version '1.6.9'
+version '1.6.10'
 
 apply plugin: 'kotlin'
 

--- a/src/main/java/com/github/grishberg/tests/ProcessCrashHandler.kt
+++ b/src/main/java/com/github/grishberg/tests/ProcessCrashHandler.kt
@@ -10,7 +10,7 @@ interface ProcessCrashHandler {
      * Is called when process crashed.
      * returns fail message for xml report.
      */
-    fun provideFailMessageOnProcessCrashed(targetDevice: ConnectedDeviceWrapper, failedTest: TestIdentifier): String
+    fun provideFailMessageOnProcessCrashed(targetDevice: ConnectedDeviceWrapper, failedTest: TestIdentifier?): String
 
     /**
      * Can be used to make a cleanup after process crashed during tests execution.
@@ -19,7 +19,7 @@ interface ProcessCrashHandler {
 
     object STUB : ProcessCrashHandler {
         override fun provideFailMessageOnProcessCrashed(device: ConnectedDeviceWrapper,
-                                                        failedTest: TestIdentifier) =
+                                                        failedTest: TestIdentifier?) =
                 "Process was crashed. See logcat for details."
 
         override fun onAfterProcessCrashed(device: ConnectedDeviceWrapper,

--- a/src/main/java/com/github/grishberg/tests/commands/reports/TestXmlReportsGenerator.java
+++ b/src/main/java/com/github/grishberg/tests/commands/reports/TestXmlReportsGenerator.java
@@ -6,6 +6,7 @@ import com.github.grishberg.tests.XmlReportGeneratorDelegate;
 import com.github.grishberg.tests.commands.reports.xml.CustomTestRunListener;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
+import org.jetbrains.annotations.Nullable;
 import org.kxml2.io.KXmlSerializer;
 
 import java.io.File;
@@ -80,6 +81,7 @@ public class TestXmlReportsGenerator extends CustomTestRunListener {
     /**
      * @return current executed test.
      */
+    @Nullable
     public TestIdentifier getCurrentTest() {
         return currentTest;
     }


### PR DESCRIPTION
Быстрофикс проблемы с  `Caused by: java.lang.IllegalArgumentException: Parameter specified as non-null is null: method `

Причина в том, что креш процесс произошел до срабатывания коллбека
```
public void testStarted(TestIdentifier test) 
```