### PR TITLE
BYIN-10660 BYIN-10661 BYIN-10678 Improve exceptions reporting.

### DIFF
--- a/src/main/java/com/github/grishberg/tests/DeviceCommandsRunner.java
+++ b/src/main/java/com/github/grishberg/tests/DeviceCommandsRunner.java
@@ -5,7 +5,6 @@ import com.github.grishberg.tests.commands.DeviceRunnerCommand;
 import com.github.grishberg.tests.commands.DeviceRunnerCommandProvider;
 import com.github.grishberg.tests.commands.CommandExecutionException;
 import com.github.grishberg.tests.common.RunnerLogger;
-import com.github.grishberg.tests.exceptions.ProcessCrashedException;
 import com.github.grishberg.tests.planner.InstrumentalTestPlanProvider;
 
 import java.util.List;
@@ -19,7 +18,9 @@ class DeviceCommandsRunner {
     private final InstrumentalTestPlanProvider testPlanProvider;
     private final DeviceRunnerCommandProvider commandProvider;
     private boolean hasFailedTests;
-    private Throwable commandException;
+    // Exception from failed child thread (should be rethrown to parent)
+    private volatile Throwable commandException;
+    private volatile String failedDeviceName;
 
     DeviceCommandsRunner(InstrumentalTestPlanProvider testPlanProvider,
                          DeviceRunnerCommandProvider commandProvider) {
@@ -34,8 +35,8 @@ class DeviceCommandsRunner {
         for (ConnectedDeviceWrapper device : devices) {
             new Thread(() -> {
                 final RunnerLogger logger = device.getLogger();
-                logger.i(TAG, "New command execution task started to run commands");
                 try {
+                    logger.i(TAG, "New command execution task started to run commands");
                     List<DeviceRunnerCommand> commands = commandProvider.provideCommandsForDevice(device,
                             testPlanProvider, environment);
                     for (DeviceRunnerCommand command : commands) {
@@ -48,13 +49,20 @@ class DeviceCommandsRunner {
                     }
                 } catch (Throwable e) {
                     logger.e(TAG, "Execute command exception:", e);
-                    commandException = e;
+                    synchronized (DeviceCommandsRunner.this) {
+                        // Save exception from the first failed child thread only
+                        if (commandException == null) {
+                            commandException = e;
+                            failedDeviceName = device.getName();
+                        }
+                    }
                 } finally {
                     deviceCounter.countDown();
                 }
                 logger.i(TAG, "Command execution task is finished");
             }).start();
         }
+        // TODO (kindrik): Use await(long timeout, TimeUnit unit) instead
         deviceCounter.await();
         throwExceptionIfNeeded();
         return !hasFailedTests;
@@ -62,13 +70,9 @@ class DeviceCommandsRunner {
 
     private void throwExceptionIfNeeded() throws CommandExecutionException {
         if (commandException != null) {
-            if (commandException instanceof CommandExecutionException) {
-                throw (CommandExecutionException) commandException;
-            }
-            if (commandException instanceof ProcessCrashedException) {
-                throw (ProcessCrashedException) commandException;
-            }
-            throw new CommandExecutionException(commandException);
+            throw new CommandExecutionException(
+                    String.format("Exception in child thread (%s)", failedDeviceName),
+                    commandException);
         }
     }
 }

--- a/src/test/java/com/github/grishberg/tests/DeviceCommandsRunnerTest.java
+++ b/src/test/java/com/github/grishberg/tests/DeviceCommandsRunnerTest.java
@@ -1,12 +1,20 @@
 package com.github.grishberg.tests;
 
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.github.grishberg.tests.commands.CommandExecutionException;
 import com.github.grishberg.tests.commands.DeviceCommandResult;
 import com.github.grishberg.tests.commands.DeviceRunnerCommand;
 import com.github.grishberg.tests.commands.DeviceRunnerCommandProvider;
-import com.github.grishberg.tests.commands.CommandExecutionException;
 import com.github.grishberg.tests.common.RunnerLogger;
+import com.github.grishberg.tests.common.TestingSimpleLogger;
 import com.github.grishberg.tests.exceptions.ProcessCrashedException;
 import com.github.grishberg.tests.planner.InstrumentalTestPlanProvider;
+
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -18,10 +26,8 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-
 /**
+ * Tests for {@link DeviceCommandsRunner}.
  * Created by grishberg on 27.03.18.
  */
 @RunWith(MockitoJUnitRunner.class)
@@ -32,7 +38,6 @@ public class DeviceCommandsRunnerTest {
     DeviceRunnerCommandProvider commandProvider;
     @Mock
     Environment environment;
-    @Mock
     RunnerLogger logger;
     @Mock
     ConnectedDeviceWrapper deviceWrapper;
@@ -50,13 +55,23 @@ public class DeviceCommandsRunnerTest {
     public void setUp() throws Exception {
         commands = new ArrayList<>();
         commands.add(command);
-        when(deviceWrapper.getLogger()).thenReturn(logger);
+        logger = spy(new TestingSimpleLogger());
+        mockDeviceBehavior(deviceWrapper,"emulator-5554", logger, result);
         when(context.getEnvironment()).thenReturn(environment);
+        devices = Arrays.asList(deviceWrapper);
+        runner = new DeviceCommandsRunner(planProvider, commandProvider);
+    }
+
+    private void mockDeviceBehavior(ConnectedDeviceWrapper deviceWrapper,
+                                    String deviceName,
+                                    RunnerLogger logger,
+                                    DeviceCommandResult result)
+            throws CommandExecutionException {
+        when(deviceWrapper.getLogger()).thenReturn(logger);
+        when(deviceWrapper.getName()).thenReturn(deviceName);
         when(commandProvider.provideCommandsForDevice(deviceWrapper, planProvider, environment))
                 .thenReturn(commands);
         when(command.execute(deviceWrapper, context)).thenReturn(result);
-        devices = Arrays.asList(deviceWrapper);
-        runner = new DeviceCommandsRunner(planProvider, commandProvider);
     }
 
     @Test
@@ -72,30 +87,113 @@ public class DeviceCommandsRunnerTest {
         verify(command).execute(deviceWrapper, context);
     }
 
-    @Test(expected = CommandExecutionException.class)
-    public void logErrorWhenException() throws Exception {
-        CommandExecutionException exception = new CommandExecutionException("Exception", new Throwable());
-        when(command.execute(deviceWrapper, context))
-                .thenThrow(exception);
-        runner.runCommands(devices, context);
-        verify(logger).e("DCR", "Execute command exception:", exception);
+    <E, F> void validateRightExceptionRaisedAndLogged(Throwable realException,
+                                                      Class<E> expectParentException,
+                                                      Class<F> expectChildException,
+                                                      Throwable exceptionToLog) {
+        if (expectParentException.isInstance(realException) &&
+                realException.getCause() != null &&
+                expectChildException.isInstance(realException.getCause())) {
+            verify(logger).e("DCR", "Execute command exception:", exceptionToLog);
+            return;
+        }
+        Assert.fail(String.format("%s (with %s) expected but have %s (with %s)",
+                expectParentException, expectChildException, realException,
+                realException.getCause()));
     }
 
-    @Test(expected = CommandExecutionException.class)
+    @Test
+    public void logErrorWhenException() throws Exception {
+        CommandExecutionException exception = new CommandExecutionException("Exception",
+                new Throwable());
+        when(command.execute(deviceWrapper, context))
+                .thenThrow(exception);
+        try {
+            runner.runCommands(devices, context);
+        } catch (Throwable e) {
+            validateRightExceptionRaisedAndLogged(e, CommandExecutionException.class,
+                    CommandExecutionException.class, exception);
+            return;
+        }
+        Assert.fail("Exception must be thrown in this test");
+    }
+
+    @Test
+    public void printDeviceNameInParentException() throws Exception {
+        CommandExecutionException exception = new CommandExecutionException("Exception",
+                new Throwable());
+        when(command.execute(deviceWrapper, context))
+                .thenThrow(exception);
+        try {
+            runner.runCommands(devices, context);
+        } catch (Throwable e) {
+            if (e instanceof CommandExecutionException) {
+                Assert.assertTrue(e.getMessage().contains("emulator-5554"));
+                return;
+            }
+            Assert.fail(String.format("Wrong exception: %s", e));
+            return;
+        }
+        Assert.fail("Exception must be thrown in this test");
+    }
+
+    @Test
     public void throwExecuteCommandExceptionWhenOtherException() throws Exception {
         NullPointerException exception = new NullPointerException();
         when(command.execute(deviceWrapper, context))
                 .thenThrow(exception);
-        runner.runCommands(devices, context);
-        verify(logger).e("DCR", "Execute command exception:", exception);
+        try {
+            runner.runCommands(devices, context);
+        } catch (Throwable e) {
+            validateRightExceptionRaisedAndLogged(e, CommandExecutionException.class,
+                    NullPointerException.class, exception);
+            return;
+        }
+        Assert.fail("Exception must be thrown in this test");
     }
 
-    @Test(expected = ProcessCrashedException.class)
+    @Test
     public void throwProcessCrashedExceptionWhenProcessCrashed() throws Exception {
         ProcessCrashedException exception = new ProcessCrashedException("test process crashed");
         when(command.execute(deviceWrapper, context))
                 .thenThrow(exception);
-        runner.runCommands(devices, context);
-        verify(logger).e("DCR", "Execute command exception:", exception);
+        try {
+            runner.runCommands(devices, context);
+        } catch (Throwable e) {
+            validateRightExceptionRaisedAndLogged(e, CommandExecutionException.class,
+                    ProcessCrashedException.class, exception);
+            return;
+        }
+        Assert.fail("Exception must be thrown in this test");
+    }
+
+    @Test
+    public void manyChildsFailed() throws Exception {
+        ConnectedDeviceWrapper deviceWrapper2 = mock(ConnectedDeviceWrapper.class);
+        RunnerLogger logger2 = spy(new TestingSimpleLogger());
+        mockDeviceBehavior(deviceWrapper2, "emulator-5555", logger2,
+                mock(DeviceCommandResult.class));
+        devices = Arrays.asList(deviceWrapper, deviceWrapper2);
+
+        NullPointerException exception1 = new NullPointerException("Exception 1");
+        IllegalStateException exception2 = new IllegalStateException("Exception 2");
+
+        when(command.execute(deviceWrapper, context))
+                .thenThrow(exception1);
+        doAnswer(invocation -> {
+            // Delay to fix randomness. This thread must be the second.
+            Thread.sleep(1);
+            throw exception2;
+        }).when(command).execute(deviceWrapper2, context);
+
+        try {
+            runner.runCommands(devices, context);
+        } catch (Throwable e) {
+            validateRightExceptionRaisedAndLogged(e, CommandExecutionException.class,
+                    NullPointerException.class, exception1);
+            verify(logger2).e("DCR", "Execute command exception:", exception2);
+            return;
+        }
+        Assert.fail("Exception must be thrown in this test");
     }
 }

--- a/src/test/java/com/github/grishberg/tests/common/TestingSimpleLogger.java
+++ b/src/test/java/com/github/grishberg/tests/common/TestingSimpleLogger.java
@@ -1,0 +1,74 @@
+package com.github.grishberg.tests.common;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * Simplified logger for testing.
+ *
+ * It is recommended to use this class or spy(TestingSimpleLogger()) in tests for comfortable work
+ * instead of default RunnerLogger.Stub or mock(RunnerLogger.class) which log nothing.
+ */
+public class TestingSimpleLogger implements RunnerLogger {
+    @Override
+    public void w(String tag, String message) {
+        log("E:", tag, message);
+    }
+
+    @Override
+    public void i(String tag, String message) {
+        log("I:", tag, message);
+    }
+
+    @Override
+    public void i(String tag, String msgFormat, Object... args) {
+        log("I:", tag, msgFormat, args);
+    }
+
+    @Override
+    public void d(String tag, String message) {
+        log("D:", tag, message);
+    }
+
+    @Override
+    public void d(String tag, String msgFormat, Object... args) {
+        log("D:", tag, msgFormat, args);
+    }
+
+    @Override
+    public void e(String tag, String message) {
+        log("E:", tag, message);
+    }
+
+    @Override
+    public void e(String tag, String message, Throwable throwable) {
+        log("E:", tag, message, throwable);
+    }
+
+    @Override
+    public void w(String tag, String msgFormat, Object... args) {
+        log("W:", tag, msgFormat, args);
+    }
+
+    private void log(String level, String tag, String message) {
+        System.out.println(String.format("%s [%s] %s", level, tag, message));
+    }
+
+    private void log(String level, String tag, String message, Throwable throwable) {
+        StringWriter out = new StringWriter();
+        throwable.printStackTrace(new PrintWriter(out));
+        System.out.println(String.format("%s [%s] %s %s", level, tag, message, out));
+    }
+
+    private void log(String level, String tag, String msgFormat, Object[] args) {
+        List<String> stringArgs =
+                Arrays.stream(args).map( it -> it == null ? "null" : it.toString() ).collect(
+                        Collectors.toList());
+        System.out.println(String.format("%s [%s] %s, ARGS = [%s]", level, tag, msgFormat,
+                String.join(", ", stringArgs)));
+    }
+
+}


### PR DESCRIPTION
This change brings 3 improvements:
- Report full execution stacktrace (parent stacktrace + child stacktrace);
- Add device name in parent exception message;
- Write the first child exception when many child threads failed;
- Synchronize access to throwable and device name to prevent collisions.

Я все проблемы, что чиню, расписал в 3 тикетах.
https://st.yandex-team.ru/BYIN-10660
https://st.yandex-team.ru/BYIN-10661
https://st.yandex-team.ru/BYIN-10678

Т.к. фиксы простые и в одном и том же месте, решил объединить вместе.

Ниже, я воспроизвёл это добавив фейковый `RuntimeException("OOPS")`, и запустив на 2 эмуляторах. Оба треда кинули исключение.
Лог, как было раньше:
https://paste.yandex-team.ru/1017662
Как стало теперь:
https://paste.yandex-team.ru/1017669
Супер! Во 2-м логе видим строчку на которой упал тест-раннер: `StandaloneModeLauncher.kt:156`
Надо понимать, что это пример, в котором запущено лишь 2 теста. В реальных логах обычно чайлдовые exception раскиданы в середине лога, их трудно искать, иногда можно случайно не заметить, и поэтому хочется получить максимум информации из финального Exception, что я и сделал в этом PR. Когда анализируешь проблемы, обычно смотришь в конец лога, где Gradle/Python/кто угодно пишет Exception и стек-трейс. Так и здесь...

p.s. Кстати, Gradle репортит все фейлы, если их было несколько (а их бывает несколько, если сборка запущена с флагом `--continue`). Но я решил, что нам здесь достаточно одного фейла, и лучше пусть это будет фейл, который произошёл первым.