### PR TITLE
BYIN-10916 Handle early crashes gracefully.

### DIFF
--- a/src/main/java/com/github/grishberg/tests/TestRunnerContext.java
+++ b/src/main/java/com/github/grishberg/tests/TestRunnerContext.java
@@ -1,5 +1,6 @@
 package com.github.grishberg.tests;
 
+import com.android.ddmlib.testrunner.TestIdentifier;
 import com.github.grishberg.tests.commands.TestRunnerBuilder;
 import com.github.grishberg.tests.common.RunnerLogger;
 
@@ -43,11 +44,13 @@ public class TestRunnerContext {
 
     public TestRunnerBuilder createTestRunnerBuilder(String projectName,
                                                      String testName,
+                                                     TestIdentifier fallbackTest,
                                                      Map<String, String> instrumentationArgs,
                                                      ConnectedDeviceWrapper targetDevice,
                                                      XmlReportGeneratorDelegate xmlDelegate) {
         return new TestRunnerBuilder(projectName,
                 testName,
+                fallbackTest,
                 instrumentationArgs,
                 targetDevice,
                 this,

--- a/src/main/java/com/github/grishberg/tests/commands/CommandExecutionException.java
+++ b/src/main/java/com/github/grishberg/tests/commands/CommandExecutionException.java
@@ -11,4 +11,8 @@ public class CommandExecutionException extends Exception {
     public CommandExecutionException(Throwable e) {
         super(e);
     }
+
+    public CommandExecutionException(String message) {
+        super(message);
+    }
 }

--- a/src/main/java/com/github/grishberg/tests/commands/InstrumentalTestCommand.java
+++ b/src/main/java/com/github/grishberg/tests/commands/InstrumentalTestCommand.java
@@ -42,6 +42,7 @@ public class InstrumentalTestCommand implements DeviceRunnerCommand {
 
         TestRunnerBuilder testRunnerBuilder = new TestRunnerBuilder(projectName,
                 "",
+                null,
                 instrumentationArgs,
                 targetDevice,
                 context,

--- a/src/main/java/com/github/grishberg/tests/commands/NoStartedTestException.java
+++ b/src/main/java/com/github/grishberg/tests/commands/NoStartedTestException.java
@@ -1,0 +1,14 @@
+package com.github.grishberg.tests.commands;
+
+/**
+ * This error can be raised when "am instrument" command crashed before any test could be started.
+ * That happens when tested application crashes too early.
+ * In such conditions our test runner cannot generate reasonable XML report because the failing
+ * tests are unknown - they were not run.
+ * Underlying test runner must handle this case in a reasonable way.
+ */
+public class NoStartedTestException extends CommandExecutionException {
+    public NoStartedTestException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/github/grishberg/tests/commands/TestRunnerBuilder.java
+++ b/src/main/java/com/github/grishberg/tests/commands/TestRunnerBuilder.java
@@ -1,11 +1,13 @@
 package com.github.grishberg.tests.commands;
 
 import com.android.ddmlib.testrunner.RemoteAndroidTestRunner;
+import com.android.ddmlib.testrunner.TestIdentifier;
 import com.android.utils.ILogger;
 import com.github.grishberg.tests.*;
 import com.github.grishberg.tests.commands.reports.*;
 import com.github.grishberg.tests.common.RunnerLogger;
 
+import javax.annotation.Nullable;
 import java.util.Map;
 
 /**
@@ -19,6 +21,8 @@ public class TestRunnerBuilder {
 
     public TestRunnerBuilder(String projectName,
                              String testGroupPrefix,
+                             @Nullable
+                             TestIdentifier fallbackTest,
                              Map<String, String> instrumentationArgs,
                              ConnectedDeviceWrapper targetDevice,
                              TestRunnerContext context,
@@ -51,6 +55,7 @@ public class TestRunnerBuilder {
                 projectName,
                 instrumentationInfo.getFlavorName(),
                 testGroupPrefix,
+                fallbackTest,
                 runTestLogger,
                 screenShotMaker,
                 logcatSaver,

--- a/src/test/java/com/github/grishberg/tests/commands/SingleInstrumentalTestCommandRetryTest.java
+++ b/src/test/java/com/github/grishberg/tests/commands/SingleInstrumentalTestCommandRetryTest.java
@@ -96,9 +96,9 @@ public class SingleInstrumentalTestCommandRetryTest {
         when(context.getProcessCrashedHandler()).thenReturn(processCrashedHandler);
         when(deviceWrapper.getLogger()).thenReturn(mock(RunnerLogger.class));
         doAnswer((Answer<TestRunnerBuilder>) invocation -> {
-            instrumentationArgs = invocation.getArgument(2);
+            instrumentationArgs = invocation.getArgument(3);
             return testRunnerBuilder;
-        }).when(context).createTestRunnerBuilder(any(), any(), any(), any(), any());
+        }).when(context).createTestRunnerBuilder(any(), any(), any(), any(), any(), any());
 
         when(testRunnerBuilder.getTestRunListener()).thenReturn(reportsGenerator);
         when(testRunnerBuilder.getTestRunner()).thenReturn(testRunner);

--- a/src/test/java/com/github/grishberg/tests/commands/SingleInstrumentalTestCommandTest.java
+++ b/src/test/java/com/github/grishberg/tests/commands/SingleInstrumentalTestCommandTest.java
@@ -87,9 +87,9 @@ public class SingleInstrumentalTestCommandTest {
         when(deviceWrapper.getLogger()).thenReturn(mock(RunnerLogger.class));
         when(environment.getCoverageDir()).thenReturn(coverageDir);
         doAnswer((Answer<TestRunnerBuilder>) invocation -> {
-            instrumentationArgs = invocation.getArgument(2);
+            instrumentationArgs = invocation.getArgument(3);
             return testRunnerBuilder;
-        }).when(context).createTestRunnerBuilder(any(), any(), any(), any(), any());
+        }).when(context).createTestRunnerBuilder(any(), any(), any(), any(), any(), any());
 
         when(testRunnerBuilder.getTestRunListener()).thenReturn(reportsGenerator);
         when(testRunnerBuilder.getTestRunner()).thenReturn(testRunner);

--- a/src/test/java/com/github/grishberg/tests/commands/TestRunnerBuilderTest.java
+++ b/src/test/java/com/github/grishberg/tests/commands/TestRunnerBuilderTest.java
@@ -45,8 +45,8 @@ public class TestRunnerBuilderTest {
         extension.setApplicationId("com.test.packageId");
         extension.setInstrumentalPackage(TEST_PACKAGE);
         extension.setInstrumentalRunner(RUNNER_NAME);
-        builder = new TestRunnerBuilder(PROJECT_NAME, TEST_NAME, args, deviceWrapper, context,
-                mock(XmlReportGeneratorDelegate.class));
+        builder = new TestRunnerBuilder(PROJECT_NAME, TEST_NAME, null, args, deviceWrapper,
+                context, mock(XmlReportGeneratorDelegate.class));
     }
 
     @Test


### PR DESCRIPTION
BYIN-10916 Handle early crashes gracefully.

When early app crash happens at the moment of instrumentation
command starts Android instrumenation framework cannot
handle this and DDMS doesn't call "testStarted()" callback
and our 'failLastTest()' handler crashes with NPE.
To fix this we provide id of the first instremented test to
the 'failLastTest()' handler.
If we cannot do this we crash it with RuntimeException().

Ура, чиню этот злополучный NPE, который всех достал. Не уверен, что это починит все кейсы, но срабатывание на тестах с рестартом Браузера должно починить.

Для `InstrumentalTestCommand.java` ничего не поменяется. NPE заменится на RuntimeException, с более понятным текстом-подсказкой (для справки - это команда означает "прогнать все тесты, найденные в test apk" - поведение стандартного гредл-раннера). Для неё исправить баг - невозможно.

Для `SingleInstrumentalTestCommand` `NPE` должен прекратиться навеки. Кстати `SingleInstrumentalTestCommand` - кривое название, ибо оно может гонять группу тестов, класс, пакет, и др. Что значит Single? Хочется переименовать, но ничего лучше пока не придумалось.