### PR TITLE
Wp/byin 10916/2 Handle early crashes gracefully (part 2)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,7 @@ plugins {
 }
 
 group 'io.github.grigory-rylov'
-version '1.6.16'
+version '1.6.17'
 
 apply plugin: 'kotlin'
 

--- a/src/main/java/com/github/grishberg/tests/commands/SingleInstrumentalTestCommand.java
+++ b/src/main/java/com/github/grishberg/tests/commands/SingleInstrumentalTestCommand.java
@@ -61,7 +61,7 @@ public class SingleInstrumentalTestCommand implements DeviceRunnerCommand {
      * @param projectName Test project name. A string included in XML result file name.
      * @param testReportSuffix Test report suffix. A string included in XML result file name.
      * @param instrumentalArgs Custom arguments for "am instrument" command passed with
-     *                         "-e <key> <value>" syntax.
+     *                         "-e [key] [value]" syntax.
      * @param testForExecution List of tests to run.
      */
     public SingleInstrumentalTestCommand(String projectName,
@@ -79,7 +79,7 @@ public class SingleInstrumentalTestCommand implements DeviceRunnerCommand {
      * @param projectName Test project name. A string included in XML result file name.
      * @param testReportSuffix Test report suffix. A string included in XML result file name.
      * @param instrumentalArgs Custom arguments for "am instrument" command passed with
-     *                         "-e <key> <value>" syntax.
+     *                         "-e [key] [value]" syntax.
      * @param testForExecution List of tests to run.
      * @param retryHandler Retry handler.
      */


### PR DESCRIPTION
Когда делал фикс https://github.com/Grigory-Rylov/android-instrumental-test-runner-core/pull/80
смотрел только на место, откуда вылетал креш - класс TestXmlReportsGenerator. И тестами только его обложил.

Но оказалось, что смотреть надо шире. `SingleInstrumentalTestCommand` пришел в неконсистентное состояние, потому что там используется 2 листенера DDMS-сообщений: `TestXmlReportsGenerator` - для XML отчетов, и `TestTracker` для восстановления тест-рана после нативного креша. Пришлось сделать аналогичный фикс для `TestTracker`, и написать тесты на `SingleInstrumentalTestCommand`.