### PR TITLE
BYIN-12771 Move Kotlin plugin import to settings.gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,18 +1,9 @@
-buildscript {
-    def kotlin_version = '1.4.30'
-
-    repositories {
-        mavenCentral()
-    }
-    dependencies {
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-    }
-}
 
 plugins {
     id "org.sonarqube" version "3.1.1"
     id 'java'
     id 'groovy'
+    id 'org.jetbrains.kotlin.jvm'
     id 'jacoco'
     id 'maven-publish'
     id 'signing'

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,2 +1,10 @@
-rootProject.name = 'android-instrumental-test-runner-core'
+pluginManagement {
+    plugins {
+        id 'org.jetbrains.kotlin.jvm' version "1.4.30"
+    }
+    repositories {
+        gradlePluginPortal()
+    }
+}
 
+rootProject.name = 'android-instrumental-test-runner-core'


### PR DESCRIPTION
BYIN-12771 Move Kotlin plugin import to settings.gradle

В Яндекс-проекте другая версия Котлин (более старая).
Вынес из `build.gradle`, чтобы применялась Яндексовая версия.
Но мы их позже уравняем.

На стороне Яндекса я не могу сделать такой фикс, т.к. там нет `settings.gradle`